### PR TITLE
Add tag-specific prev/next navigation cards

### DIFF
--- a/themes/PaperMod/assets/css/extended/blank.css
+++ b/themes/PaperMod/assets/css/extended/blank.css
@@ -3,3 +3,38 @@ This is just a placeholder blank stylesheet so as to support adding custom style
 
 Read https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#bundling-custom-css-with-themes-assets for more info
 */
+
+/* Tag-specific navigation cards */
+.tag-nav-section {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag-nav-card {
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--entry);
+}
+
+.tag-nav-header {
+    margin: 0 0 0.75rem 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--secondary);
+    text-transform: lowercase;
+}
+
+.tag-nav-header a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+.tag-nav-header a:hover {
+    text-decoration: underline;
+}
+
+.tag-nav-card .paginav {
+    margin: 0;
+}

--- a/themes/PaperMod/layouts/_default/single.html
+++ b/themes/PaperMod/layouts/_default/single.html
@@ -55,6 +55,7 @@
       <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
       {{- end }}
     </ul>
+    {{- partial "post_tag_nav_links.html" . }}
     {{- if (.Param "ShowPostNavLinks") }}
     {{- partial "post_nav_links.html" . }}
     {{- end }}

--- a/themes/PaperMod/layouts/partials/post_tag_nav_links.html
+++ b/themes/PaperMod/layouts/partials/post_tag_nav_links.html
@@ -1,0 +1,44 @@
+{{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+{{- $currentTags := $.GetTerms $tags }}
+{{- if gt (len $currentTags) 0 }}
+<div class="tag-nav-section">
+  {{- range $currentTags }}
+    {{- $currentPage := $ }}
+    {{- $tagName := .LinkTitle }}
+    {{- $tagNameLower := lower $tagName }}
+    {{- $tagPages := slice }}
+    {{- range $page := where site.RegularPages "Type" "in" site.Params.mainSections }}
+      {{- range .Params.tags }}
+        {{- if eq (lower .) $tagNameLower }}
+          {{- $tagPages = $tagPages | append $page }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if gt (len $tagPages) 1 }}
+      {{- $prevInTag := ($tagPages.Next $currentPage) }}
+      {{- $nextInTag := ($tagPages.Prev $currentPage) }}
+      {{- if or $prevInTag $nextInTag }}
+      <div class="tag-nav-card">
+        <h3 class="tag-nav-header">in <a href="{{ .Permalink }}">{{ .LinkTitle }}</a></h3>
+        <nav class="paginav">
+          {{- with $prevInTag }}
+          <a class="prev" href="{{ .Permalink }}">
+            <span class="title">« Prev</span>
+            <br>
+            <span>{{- .Name -}}</span>
+          </a>
+          {{- end }}
+          {{- with $nextInTag }}
+          <a class="next" href="{{ .Permalink }}">
+            <span class="title">Next »</span>
+            <br>
+            <span>{{- .Name -}}</span>
+          </a>
+          {{- end }}
+        </nav>
+      </div>
+      {{- end }}
+    {{- end }}
+  {{- end }}
+</div>
+{{- end }}


### PR DESCRIPTION
## Summary

Implements #15 to add tag-specific "Next article" and "Prev article" navigation for each tag on a post. 

When viewing a post with multiple tags (e.g., vim, linux, productivity), readers now see separate navigation cards for each tag, allowing them to traverse articles within a specific topic. This makes it much easier to explore all content related to a particular interest.

## Changes

- **New partial:** Created `post_tag_nav_links.html` that generates navigation cards for each tag on the current post
- **Integration:** Added the new partial to `single.html`, placing it after the tag list and before share buttons
- **Styling:** Added CSS in `blank.css` for the tag navigation cards with proper spacing, borders, and hover effects
- **Smart filtering:** Navigation only appears for tags that have 2+ posts, and only shows prev/next if there are adjacent posts in that tag
- **Case-insensitive:** Uses case-insensitive tag matching to handle variations between frontmatter and LinkTitle

## Test Plan

- [x] Tested locally with `hugo serve`
- [x] Verified navigation appears on posts with multiple tags
- [x] Confirmed prev/next links work correctly for each tag
- [x] Checked that tags with only 1 post don't show navigation
- [x] Validated styling matches PaperMod theme
- [x] Tested case-insensitive tag matching

## Example

For a post tagged with [anki, linux, builds]:
- Shows "in Anki" card with prev/next articles also tagged with anki
- Shows "in Linux" card with prev/next articles also tagged with linux  
- Shows "in Builds" card with prev/next articles also tagged with builds

## Implementation Notes

The feature uses Hugo's built-in page collections and filtering. Each tag generates its own filtered collection of posts, then uses Hugo's `.Next` and `.Prev` methods to find adjacent posts within that collection.